### PR TITLE
Rewrite commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ let g:Boop_default_action = '.'
 :let g:Boop_default_action = 'pad:visual'
 ```
 
-Using the default keybinds, Ctrl-B will open the Boop scratchpad from normal
-mode. Pressing Ctrl-B within this scratch which runs a boop script on the entire scratch pad (or any
+Using the default keybinds, Ctrl-B will open the Boop scratchpad from normal mode.
+Pressing Ctrl-B within this scratch runs a boop script on the entire scratch pad (or any
 file). In visual mode, Ctrl-B will similarly populate your Vim command line
 with `:'<,'>Boop `, which will run a boop script on only the current selection
 (once, not linewise).
@@ -118,6 +118,6 @@ using this [3rd-party build of rusty_v8](https://github.com/fm-elpac/v8-src/rele
 4. (For Vim) Add the plugin to your favorite plugin manager by path, or
    move/symlink the Boop.nvim/ directory into place. For vim native packages on
    Linux/MacOS you can do:  
-   `mkdir -p ~/.vim/pack/gmvi/start/ && ln -s . ~/.vim/pack/gmvi/start/boop.vim`
+   `mkdir -p ~/.vim/pack/gmvi/start/ && ln -s . ~/.vim/pack/gmvi/start/Boop.nvim`
 5. (For Neovim) Add the plugin to your plugin manager by path.  
    For Lazy.nvim, I use `{ dir = "~/src/Boop.nvim" }`

--- a/README.md
+++ b/README.md
@@ -34,6 +34,76 @@ supported platforms:
 * Android (e.g. Termux), but cross-compilation may be possible (see next section).
 
 
+## Usage
+Put custom boop scripts in `~/.config/boop/`
+
+Boop.nvim provides the following Ex commands to run scripts and open the Boop pad
+```vim
+" Applies a script to either the current file (default), or specific lines if a <range> is provided.
+" In Neovim, calling with no <script name> opens a popup list of scripts with descriptions.
+:Boop <script name>
+:.Boop <script name> " Boops just the current line
+" If you want :Boop to apply to just the current line by default, set g:Boop_default_action
+let g:Boop_default_action = '.'
+" Use :%Boop to boop the entire file regardless of g:Boop_default_action
+:%Boop <script name> 
+" From visual mode, calling :Boop will apply a script only to the visual selection
+" Vim will insert :'<,'> for you; this is the range of lines covered by the selection
+" The :Boop command will use your actual visual selection, rather than linewise
+:'<,'>Boop <script name>
+"TODO: make blockwise visual selection work
+
+" Opens the Boop scratch-pad, which provides an experience similar to the original Boop app.
+:BoopPad
+" From visual mode, this will open the Boop pad with the most recent visual selection
+:'<,'>BoopPad
+" In neovim, it's a floating window. In vim, it's a scratch buffer in a split.
+" (see `:help scratch` or https://vimhelp.org/windows.txt.html#scratch-buffer )
+" :BoopPad forwards modifiers to :new, and calling it twice won't open multiple splits.
+" You can also use these modifiers in Neovim to open the Boop pad in a split or a tab.
+:horiz BoopPad " default for Vim
+:vert BoopPad
+:tab BoopPad
+"TODO: make these work for neovim after already opening the floating window
+" TODO: implement :browse BoopPad and :BoopPad {path}
+
+" After running a script you can replace your old selection with the result like this:
+" :%y or ggyG to yank the entire Boop pad
+" :q or ZQ or <c-w>c to close the Boop pad
+" gvp to paste over your old selection (mnemonic: "go visual; paste", see :help gv)
+
+" Other ways to use g:Boop_default_action to change the default behavior of the :Boop command:
+" 'pad' - calling just :Boop from normal mode, with no range or script, acts like :BoopPad
+:let g:Boop_default_action = 'pad' 
+" 'pad:visual' - like 'pad', but calling just :Boop from visual mode also acts like :BoopPad
+:let g:Boop_default_action = 'pad:visual'
+```
+
+Using the default keybinds, Ctrl-B will open the Boop scratchpad from normal
+mode. Pressing Ctrl-B within this scratch which runs a boop script on the entire scratch pad (or any
+file). In visual mode, Ctrl-B will similarly populate your Vim command line
+with `:'<,'>Boop `, which will run a boop script on only the current selection
+(once, not linewise).
+
+You can turn off the default keybinds with
+`let g:Boop_use_default_mappings = 1` (vimscript) or
+`vim.g.Boop_use_default_mappings = 1` (lua)
+
+To define custom keymaps only within the Boop pad, use a filetype autocmd:
+```vim
+augroup boop_user_mapping
+    autocmd!
+    autocmd BufEnter,FileType boop call s:BoopUserMapping()
+augroup END
+
+function! s:BoopUserMapping()
+    " Press <ctrl-l> to see a list of all boop scripts.
+    nnoremap <buffer> <c-l> :ListBoopScripts<cr>
+endfunction
+```
+To use the above in lua, you can wrap it with `vim.cmd([[` and `]])`
+
+
 ## Manual Install and Build from Source
 Requires [Rust](https://www.rust-lang.org/learn/get-started). On Windows, requires
 [msvc build tools](https://rust-lang.github.io/rustup/installation/windows-msvc.html).
@@ -51,33 +121,3 @@ using this [3rd-party build of rusty_v8](https://github.com/fm-elpac/v8-src/rele
    `mkdir -p ~/.vim/pack/gmvi/start/ && ln -s . ~/.vim/pack/gmvi/start/boop.vim`
 5. (For Neovim) Add the plugin to your plugin manager by path.  
    For Lazy.nvim, I use `{ dir = "~/src/Boop.nvim" }`
-
-
-## Usage
-Put custom boop scripts in `~/.config/boop/`
-
-Using the default keybinds, Ctrl-B will open the Boop scratchpad from normal
-mode. Pressing Ctrl-B again will populate your Vim command line with
-`:BoopBuffer `, which runs a boop script on the entire scratch pad (or any
-file). In visual mode, Ctrl-B will similarly populate your Vim command line
-with `:'<,'>Boop `, which will run a boop script on only the current selection
-(once, not linewise).
-
-You can turn off the default keybinds with
-`let g:Boop_use_default_mappings = 1` (vimscript) or
-`vim.g.Boop_use_default_mappings = 1` (lua)
-
-To define custom keymaps specific to the Boop scratch pad, use a filetype
-autocmd:
-```vim
-augroup boop_user_mapping
-    autocmd!
-    autocmd BufEnter,FileType boop call s:BoopUserMapping()
-augroup END
-
-function! s:BoopUserMapping()
-    " Press <ctrl-l> to see a list of all boop scripts.
-    nnoremap <buffer> <c-l> :ListBoopScripts<cr>
-endfunction
-```
-To use the above in lua, you can wrap it with `vim.cmd([[` and `]])`

--- a/autoload/boop.vim
+++ b/autoload/boop.vim
@@ -1,19 +1,41 @@
-""" This file contains functions for installing the scripting engine
+""" This file contains globals and functions for installing the scripting engine
 
+if !exists('g:Boop_use_oldscratch')
+    let g:Boop_use_oldscratch = 0
+endif
+if !exists('g:Boop_use_oldsystem')
+    let g:Boop_use_oldsystem = 0
+endif
+if !exists('g:Boop_use_palette')
+    let g:Boop_use_palette = 1
+endif
+if !exists('g:Boop_use_default_mappings')
+    let g:Boop_use_default_mappings = 1
+endif
+if !exists('g:Boop_default_action')
+    let g:Boop_default_action = '%'
+endif
 if !exists('g:Boop_force_build')
     let g:Boop_force_build = 0
 endif
+""" turn features on/off based on vim/neovim version and g:Boop_use_ settings
+let g:boop#use_engine = has('nvim-0.6') && has('job') && !g:Boop_use_oldsystem
+            \ ? 'job' : 'system'
+let g:boop#use_floating = has('nvim-0.5') && !g:Boop_use_oldscratch
+let g:boop#use_palette = !g:Boop_use_palette
+            \ ? 'none'
+            \ : has('nvim-0.5') ? 'floating'
+            \ : v:version >= 802 ? 'popup'
+            \ : 'none'
+
 
 fun! boop#check_engine(...)
     " if the binary is found, assume it installed correctly
     if glob(g:boop#util#bin_path) !=# ""
         return 1
-    " if a:1 is falsey, don't install the engine
-    elseif a:0 && !a:1
-        return 0
-    else
-        return s:install_engine()
     endif
+    " if the first argument is 0, don't install the engine
+    return (a:0 && !a:1) ? 0 : s:install_engine()
 endfun
 
 fun! boop#reinstall_engine()

--- a/autoload/boop/floating.vim
+++ b/autoload/boop/floating.vim
@@ -20,12 +20,10 @@ fun! boop#floating#open_scratch() abort
     augroup END
 endfun
 
-fun! boop#floating#open_palette() abort
-    if s:boop_palette == 'floating'
-        throw "s:boop_palette == 'floating' not implemented yet"
-    elseif s:boop_palette == 'popup'
-        throw "s:boop_palette == 'popup' not implemented yet"
+fun! boop#floating#open_palette()
+    if has('nvim')
+        throw "floating palette not implemented yet"
     else " s:boop_palette == 'none'
-        throw "Boop.vim: s:OpenBoopPalette() called with s:boop_palette == 'none'"
+        throw "floating palette not supported in vim"
     endif
 endfun

--- a/autoload/boop/oldvim.vim
+++ b/autoload/boop/oldvim.vim
@@ -1,11 +1,7 @@
 fun! boop#oldvim#init() abort
     fun! s:f()
         let s:oldvim_init_success = 0
-        if g:boop#util#unixlike
-            let l:touch = "touch"
-        else " has('win32')
-            let l:touch = "copy nul"
-        endif
+        let l:touch = g:boop#util#unixlike ? 'touch' : 'copy nul'
         if !exists("g:boop#oldvim#info_file")
             let g:boop#oldvim#info_file = tempname()
         endif
@@ -34,3 +30,58 @@ fun! boop#oldvim#init() abort
     endif
     return 1
 endfun
+
+fun! boop#oldvim#cleanup() abort
+    if exists("g:boop#oldvim#info_file")
+        call delete(g:boop#oldvim#info_file)
+    endif
+    if exists("g:boop#oldvim#error_file")
+        call delete(g:boop#oldvim#error_file)
+    endif
+endfun
+
+" Rewrites the previous command in history and then presses the tab key
+" This function enables commands in oldvim to open completion
+fun! boop#oldvim#press_tab(command)
+    let l:cmd_history_latest = histget(':', -1)
+    if l:cmd_history_latest[-1:] != ' '
+        let l:cmd_history_latest ..= ' '
+    endif
+    call histdel(':', -1)
+    call feedkeys(':'..l:cmd_history_latest.."\<Tab>", 't')
+endfun
+
+" Enables a command that prints all the script names
+fun! boop#oldvim#ListBoopScripts()
+    if g:boop#use_engine == 'system'
+        let l:scripts = split(system(g:boop#util#bin_path ..' -l'), '\r\?\n')
+    else " g:boop#use_engine == 'job'
+        throw "g:boop#use_engine == 'job' not implemented yet"
+    endif
+    let l:n_columns = 3
+    let l:columns = s:cut_into_columns(l:scripts, l:n_columns)
+    let l:width = (81/l:n_columns)-1
+    for j in range(len(l:columns[0]))
+        echo ''
+        for i in range(l:n_columns)
+            try | let l:item = l:columns[i][j] | catch | break | endtry
+            echon printf('%-'..l:width..'S', l:item[:l:width-1])
+            if i < l:n_columns-1 | echon ' ' | endif
+        endfor
+    endfor
+endfun
+
+fun! s:cut_into_columns(list, n_columns) abort
+    let l:remainder = len(a:list) % a:n_columns
+    let l:height = (len(a:list) / a:n_columns) + (l:remainder > 0)
+    let l:columns = []
+    let j = 0
+    for i in range(a:n_columns)
+        let k = j+l:height
+        if i >= l:remainder | let k = k-1 | endif
+        call add(l:columns, a:list[j:k-1])
+        let j = k
+    endfor
+    return l:columns
+endfun
+

--- a/plugin/boop.vim
+++ b/plugin/boop.vim
@@ -1,69 +1,64 @@
-""" User Settings
-if !exists('g:Boop_use_oldscratch')
-    let g:Boop_use_oldscratch = 0
-endif
-if !exists('g:Boop_use_oldsystem')
-    let g:Boop_use_oldsystem = 0
-endif
-"if !exists('g:Boop_use_palette')
-"    let g:Boop_use_palette = 1
-"endif
-if !exists('g:Boop_use_default_mappings')
-    let g:Boop_use_default_mappings = 1
-endif
-
-""" Select features based on vim/neovim version
-if has('nvim-0.6') && has('job') && !g:Boop_use_oldsystem
-    let s:boop_engine_interface = 'job'
-else
-    let s:boop_engine_interface = 'system'
-endif
-if has('nvim-0.5') && !g:Boop_use_oldscratch
-    let s:boop_pad_ui = 'floating'
-else
-    let s:boop_pad_ui = 'scratch'
-endif
-"if has('nvim-0.5') && g:Boop_use_palette
-"    let s:boop_palette = 'floating'
-"elseif v:version >= 802 && g:Boop_use_palette
-"    let s:boop_palette = 'popup'
-"else
-"    let s:boop_palette = 'none'
-"endif
+let s:boop_register = 'x'
 
 " These overrides are for features not yet built
-let s:boop_engine_interface = 'system'
-let s:boop_palette = 'none'
+let g:boop#use_engine = 'system'
+let g:boop#use_palette = 'none'
 
-" Configure the selected features
-if s:boop_engine_interface == 'system'
+" Initialize the engine
+if g:boop#use_engine == 'system'
     call boop#oldvim#init()
-else " s:boop_engine_interface == 'job'
-    throw "s:boop_engine_interface == 'job' not implemented yet"
+else " g:boop#use_engine == 'job'
+    throw "g:boop#use_engine == 'job' not implemented yet"
     call boop#neovim#init()
 endif
 " Required for refocusing the scratch pad implementation
 " TODO: implement use of window ID like in NERDTree/NERDTreeFocus
 "let s:scratch_window = -1
-if s:boop_pad_ui == 'scratch'
+if !g:boop#use_floating
     set switchbuf +=useopen
 endif
 
 
 """ Main functions 
-fun! s:BoopPad(mods) abort
-    if !boop#check_engine()
-        return
+fun! s:CmdBoopPad(mods, range) abort
+    if !boop#check_engine() | return | endif
+    " if the default is a floating window, then ignore that if a directional
+    " split modifier is present
+    let l:use_floating = g:boop#use_floating
+    if l:use_floating && a:mods
+        for m in [ 'aboveleft', 'belowright', 'botright', 'horizontal',
+                 \ 'leftabove', 'rightbelow', 'tab', 'topleft', 'vertical',
+                 \ ]
+            if stridx(a:mods, m) >= 0
+                let l:use_floating = 0
+                break
+            endif
+        endfor
     endif
-    if s:boop_pad_ui == 'floating'
+    " if invoked from visual mode, copy the selection into the scratch pad
+    let l:from_visual = 0
+    let l:reg_old_contents = getreg(s:boop_register)
+    if a:range == 2 && histget(':', -1)[:4] ==# "'<,'>"
+        let l:from_visual = 1
+        silent exec "normal!" "gv\""..s:boop_register.."y"
+    endif
+    call s:open_boop_pad(a:mods)
+    if l:from_visual
+        silent exec "%delete _ | %put" s:boop_register "| 0delete _"
+        call setreg(s:boop_register, l:reg_old_contents)
+    endif
+endfun
+
+fun! s:open_boop_pad(mods) abort
+    if g:boop#use_floating
         call boop#floating#open_scratch()
         try
-            b \[Boop]
+            buffer \[Boop]
             return
         catch
             " new buffer, continue on to set local options and mappings
         endtry
-    else " s:boop_pad_ui == 'scratch'
+    else
         try
             exec a:mods "sbuffer \\[Boop]"
             return
@@ -76,40 +71,34 @@ fun! s:BoopPad(mods) abort
     setlocal nobuflisted buftype=nofile bufhidden=hide noswapfile
     setlocal filetype=boop
     if g:Boop_use_default_mappings
-        nnoremap <buffer> <c-b> :BoopBuffer<space>
+        nnoremap <buffer> <c-b> :%Boop<space>
     endif
 endfun
 
 " Open the boop pad with the most recent selection (using :normal! gv)
 fun! s:BoopPadFromSelection(mods) abort
-    if !boop#check_engine()
-        return
-    endif
+    if !boop#check_engine() | return | endif
     " remember the user's old register contents
-    let l:reg_old = getreg(s:boop_reg)
+    let l:reg_old = getreg(s:boop_register)
     try
-        silent exec "normal!" "gv\""..s:boop_reg.."y"
+        silent exec "normal!" "gv\""..s:boop_register.."y"
         BoopPad
-        exec "normal!" "ggVG\""..s:boop_reg.."p"
+        exec "normal!" "ggVG\""..s:boop_register.."p"
     endtry
-    call setreg(s:boop_reg, l:reg_old)
+    call setreg(s:boop_register, l:reg_old)
 endfun
 
 
-""" Do the booping (core functions; user-facing commands below)
-
 fun! s:BoopCompletion(ArgLead, CmdLine, CursorPos) abort
-    if !boop#check_engine(v:false)
-        return
-    endif
+    if !boop#check_engine(v:false) | return | endif
     let l:idx_first_space = stridx(a:CmdLine, ' ')
     let l:left_of_cursor = a:CmdLine[l:idx_first_space+1:a:CursorPos]
     let l:len_prev_args = a:CursorPos - strlen(a:ArgLead) - l:idx_first_space - 1
     " get the list of scripts
-    if s:boop_engine_interface == "system"
+    if g:boop#use_engine == "system"
         let l:script_list = split(system(g:boop#util#bin_path.." -l"), '\n')
-    else "s:boop_engine_interface == 'job'
-        throw "s:boop_engine_interface == 'job' not implemented yet"
+    else "g:boop#use_engine == 'job'
+        throw "g:boop#use_engine == 'job' not implemented yet"
     endif
     let l:matches = filter(l:script_list, 'v:val =~ "^"..l:left_of_cursor')
     " because the completion engine only understands space-separated
@@ -117,15 +106,12 @@ fun! s:BoopCompletion(ArgLead, CmdLine, CursorPos) abort
     return map(l:matches, 'v:val[l:len_prev_args:]')
 endfun
 
-let s:boop_reg = 'x'
 fun! s:DoBoop(args) abort
-    " the `, 1, 1` below is to not translate NULs to newlines -- VimL is weird
-    let l:input = getreg(s:boop_reg, 1, 1)
-    if s:boop_engine_interface == "system"
-        " Try to init again in case the user fixed a system issue (e.g.
-        " filesystem permissions). This will exit early if init already
-        " succeeded.
+    " the additional arguments to getreg tell it not to translate NULs to newlines
+    let l:input = getreg(s:boop_register, 1, 1)
+    if g:boop#use_engine == "system"
         if !boop#oldvim#init()
+            " Abort if init failed
             return 0
         endif
 
@@ -170,7 +156,8 @@ fun! s:DoBoop(args) abort
             endif
         endtry
 
-        call setreg(s:boop_reg, l:output)
+        call setreg(s:boop_register, l:output)
+        " return success if input and output are different lines
         return l:input !=# split(l:output, '\r\?\n', 1)
 
     else "s:boop_engine_interface == 'job'
@@ -179,91 +166,93 @@ fun! s:DoBoop(args) abort
     endif
 endfun
 
-" Boops the entire buffer
-fun! s:BoopBuffer(args) abort
+" Boops either a range of lines, or (from visual mode) the most recent selection
+fun! s:CmdBoop(args, mods, range, line1, line2) abort
+    " TODO: bugfix: `vap:boop [script]<cr>` removes a preceding newline
     if !boop#check_engine()
         return
     endif
-    let script = len(a:args) ? a:args : boop#floating#open_scratch()
-    " remember the user's old register contents
-    let l:reg_old = getreg(s:boop_reg)
-    try
-        silent exec "%yank" s:boop_reg
-        if s:DoBoop(a:args)
-            silent exec "normal!" "gg\"_dG\""..s:boop_reg.."P"
+    let l:from_visual = 0
+    if a:range == 2 && histget(':', -1)[:4] ==# "'<,'>"
+        let l:from_visual = 1
+        " if invoked from visual mode with no script and g:Boop_default_action
+        " is 'fromselection', then load the selection into the Boop pad
+        if !strlen(a:args) && g:Boop_default_action =~ '^\.\?fromselection$'
+            return s:BoopPadFromSelection('')
         endif
-    endtry
-    call setreg(s:boop_reg, l:reg_old)
-endfun
-
-" Boops the current line. Does not affect the recent selection (gv)
-" TODO: make this work linewise instead of just one single line
-fun! s:BoopLine(args) abort
-    if !boop#check_engine()
+    else
+        " if invoked from normal mode with no script and g:Boop_default_action is
+        " 'pad' or 'fromselection', then open the Boop pad
+        if !strlen(a:args) && g:Boop_default_action =~ '^\.\?\(pad\|fromselection\)$'
+            return s:BoopPad(a:mods, a:range)
+        endif
+    endif
+    " If you invoke :Boop with no arguments in oldvim, start completion
+    if g:boop#use_palette == 'none' && !strlen(a:args)
+        return boop#oldvim#press_tab('Boop')
+    endif
+    let script = strlen(a:args) ? a:args : boop#floating#open_palette()
+    if !strlen(script)
+        echohl ErrorMsg | echom "[Boop.nvim] Error: no script selected" | echohl None
         return
     endif
-    let script = len(a:args) ? a:args : boop#floating#open_scratch()
-    " remember the user's old register contents
-    let l:reg_old_contents = getreg(s:boop_reg)
+    " remember the old register contents
+    let l:reg_old_contents = getreg(s:boop_register)
     try
-        silent exec "yank" s:boop_reg
-        if s:DoBoop(a:args)
-            " do a `substitute` instead of some normal! dd/P command, cause it
-            " wasn't working for me.
-            let l:search_reg = getreg('/')
-            silent exec "substitute" "/.*/\\=@"..s:boop_reg.."/"
-            call setreg('/', l:search_reg)
+        if l:from_visual
+            " if the command was triggered from visual mode, then boop the selection
+            silent exec 'normal!' 'gv"'..s:boop_register..'y'
+            let l:boop_success = s:DoBoop(script)
+            if l:boop_success
+                " only paste if the script succeeded
+                silent exec 'normal!' 'gv"'..s:boop_register..'p'
+            endif
+        else " normal mode
+            if a:line1==0 && a:line2==line('$')
+                " if the range is the whole buffer, track it as % for later
+                let l:range = '%'
+            else
+                let l:range = a:line1..','..a:line2
+            endif
+            " if no range was given and '.' is not the default range, boop the whole buffer
+            if a:range == 0 && g:Boop_default_action[0] != '.'
+                let l:range = '%'
+            endif
+            silent exec l:range 'yank' s:boop_register
+            let l:boop_success = s:DoBoop(script)
+            if l:boop_success
+                " only paste if the script succeeded
+                silent exec l:range 'delete _'
+                silent exec line('.')-1 'put' s:boop_register
+                " %delete creates an extra newline
+                if l:range == '%' && line('$') > 1
+                    silent exec '$delete _'
+                endif
+                "TODO: return to the original cursor position
+            endif
         endif
+    finally
+        call setreg(s:boop_register, l:reg_old_contents)
     endtry
-    call setreg(s:boop_reg, l:reg_old_contents)
 endfun
 
-" Boops the most recent selection (i.e. the current selection if triggered from visual mode)
-" TODO: bugfix: `vap:boop [script]<cr>` removes a trailing newline
-fun! s:BoopSelection(args) abort
-    if !boop#check_engine()
-        return
-    endif
-    let script = len(a:args) ? a:args : boop#floating#open_scratch()
-    " remember the user's old register contents
-    let l:reg_old = getreg(s:boop_reg)
-    try
-        silent exec "normal!" "gv\""..s:boop_reg.."y"
-        if s:DoBoop(script)
-            silent exec "normal!" "gv\""..s:boop_reg.."p"
-        endif
-    endtry
-    call setreg(s:boop_reg, l:reg_old)
-endfun
+" Command definitions
+command! -range BoopPad call s:CmdBoopPad(<q-mods>, <range>)
+command! -range -nargs=? -complete=customlist,s:BoopCompletion Boop
+            \ call s:CmdBoop(<q-args>, <q-mods>, <range>, <line1>, <line2>)
+command! ListBoopScripts call boop#oldvim#ListBoopScripts()
 
-" Boop pad commands
-" In vim the boop pad opens as a split, so apply <q-mods>
-command! BoopPad call s:BoopPad(<q-mods>)
-command! -range BoopPadFromSelection call s:BoopPadFromSelection(<q-mods>)
-" Boop commands
-if s:boop_palette == 'none'
-    " If you invoke Boop with no arguments in oldvim, have it press tab for you
-    command! -nargs=* -complete=customlist,s:BoopCompletion -range Boop 
-        \ eval <q-args>=="" ? feedkeys(":Boop \<Tab>", 't') : s:BoopSelection(<q-args>)
-    command! -nargs=* -complete=customlist,s:BoopCompletion BoopBuffer
-        \ eval <q-args>=="" ? feedkeys(":BoopBuffer \<Tab>", 't') : s:BoopBuffer(<q-args>)
-    "command! -nargs=* -complete=custom,s:BoopCompletion BoopLine
-    "    \ eval <q-args>=="" ? feedkeys(":BoopLine \<Tab>", 't') : s:BoopLine(<q-args>)
-else
-    " In neovim, calling these commands with no arguments will open the floating palette
-    command! -nargs=* -complete=customlist,s:BoopCompletion -range Boop call s:BoopSelection(<q-args>)
-    command! -nargs=* -complete=customlist,s:BoopCompletion BoopBuffer call s:BoopBuffer(<q-args>)
-    "command! -nargs=* -complete=custom,s:BoopCompletion BoopLine call s:BoopLine(<q-args>)
-endif
-" Command to display the list of available scripts
-if has('unix') || has('osxunix')
-    " You may prefer a different value than -3 below
-    command! ListBoopScripts !echo; boop -l | pr -3 -t
-elseif has('win32')
-    command! ListBoopScripts !echo.& boop -l
-endif
 
-if g:Boop_use_default_mappings
+
+fun! s:apply_default_mappings()
+    " TODO: what effect would using <cmd> mappings have here?
     nnoremap <c-b> :BoopPad<CR>
-    xnoremap <c-b> :Boop<Space>
+    if g:boop#use_palette == 'none'
+        vnoremap <c-b> :Boop<Space>
+    else
+        vnoremap <c-b> :Boop<CR>
+    endif
+endfun
+if g:Boop_use_default_mappings
+    call s:apply_default_mappings()
 endif


### PR DESCRIPTION
* Expand Usage section of README.md
* Move configuration globals and feature flags into autoload/boop.vim
* Implement :ListBoopScripts natively in vimscript to better support windows
* Simplify and unify logic
* Condense five :Boop* commands into just :Boop and :BoopPad
* Add configuration for what :Boop does when called with no script